### PR TITLE
PAY-828 - using generic auth-checker-lib rather than idam specific one.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -33,7 +33,7 @@ def javaLoggingVersion = '3.0.1'
 dependencies {
     compile project(':fees-register-model')
     compile project(':fees-register-api-contract')
-    compile (group: 'uk.gov.hmcts.auth.checker', name: 'auth-checker-spring', version: '[1.0, )') {
+    compile (group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.2') {
         exclude(module: 'java-logging-spring')
     }
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'

--- a/api/src/main/java/uk/gov/hmcts/fees/register/api/configuration/AuthCheckerConfiguration.java
+++ b/api/src/main/java/uk/gov/hmcts/fees/register/api/configuration/AuthCheckerConfiguration.java
@@ -4,12 +4,11 @@ package uk.gov.hmcts.fees.register.api.configuration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import uk.gov.hmcts.auth.checker.RequestAuthorizer;
-import uk.gov.hmcts.auth.checker.spring.useronly.AuthCheckerUserOnlyFilter;
-import uk.gov.hmcts.auth.checker.user.User;
+import uk.gov.hmcts.reform.auth.checker.core.RequestAuthorizer;
+import uk.gov.hmcts.reform.auth.checker.core.user.User;
+import uk.gov.hmcts.reform.auth.checker.spring.useronly.AuthCheckerUserOnlyFilter;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;

--- a/api/src/main/java/uk/gov/hmcts/fees/register/api/configuration/SpringSecurityConfiguration.java
+++ b/api/src/main/java/uk/gov/hmcts/fees/register/api/configuration/SpringSecurityConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import uk.gov.hmcts.auth.checker.spring.useronly.AuthCheckerUserOnlyFilter;
+import uk.gov.hmcts.reform.auth.checker.spring.useronly.AuthCheckerUserOnlyFilter;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 

--- a/api/src/test/java/uk/gov/hmcts/fees/register/api/componenttests/ComponentTestConfiguration.java
+++ b/api/src/test/java/uk/gov/hmcts/fees/register/api/componenttests/ComponentTestConfiguration.java
@@ -3,9 +3,9 @@ package uk.gov.hmcts.fees.register.api.componenttests;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import uk.gov.hmcts.auth.checker.SubjectResolver;
-import uk.gov.hmcts.auth.checker.user.User;
 import uk.gov.hmcts.fees.register.api.componenttests.backdoors.UserResolverBackdoor;
+import uk.gov.hmcts.reform.auth.checker.core.SubjectResolver;
+import uk.gov.hmcts.reform.auth.checker.core.user.User;
 
 @Configuration
 public class ComponentTestConfiguration {

--- a/api/src/test/java/uk/gov/hmcts/fees/register/api/componenttests/backdoors/UserResolverBackdoor.java
+++ b/api/src/test/java/uk/gov/hmcts/fees/register/api/componenttests/backdoors/UserResolverBackdoor.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.fees.register.api.componenttests.backdoors;
 
 import com.google.common.collect.ImmutableSet;
-import uk.gov.hmcts.auth.checker.SubjectResolver;
-import uk.gov.hmcts.auth.checker.exceptions.AuthCheckerException;
-import uk.gov.hmcts.auth.checker.user.User;
+import uk.gov.hmcts.reform.auth.checker.core.SubjectResolver;
+import uk.gov.hmcts.reform.auth.checker.core.exceptions.AuthCheckerException;
+import uk.gov.hmcts.reform.auth.checker.core.user.User;
 
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/api/src/test/java/uk/gov/hmcts/fees/register/api/componenttests/sugar/RestActions.java
+++ b/api/src/test/java/uk/gov/hmcts/fees/register/api/componenttests/sugar/RestActions.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import uk.gov.hmcts.auth.checker.user.UserRequestAuthorizer;
 import uk.gov.hmcts.fees.register.api.componenttests.backdoors.UserResolverBackdoor;
+import uk.gov.hmcts.reform.auth.checker.core.user.UserRequestAuthorizer;
 
 import java.util.UUID;
 

--- a/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/FeeVersionControllerSecurityTest.java
+++ b/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/FeeVersionControllerSecurityTest.java
@@ -13,15 +13,13 @@ import org.springframework.security.core.Authentication;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.auth.checker.RequestAuthorizer;
 import uk.gov.hmcts.fees2.register.api.controllers.mapper.FeeDtoMapper;
 import uk.gov.hmcts.fees2.register.data.service.FeeVersionService;
+import uk.gov.hmcts.reform.auth.checker.core.RequestAuthorizer;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.fees2.register.api.FeeTestFixtures.aFeeVersionPayload;
 

--- a/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/TestSecurityConfiguration.java
+++ b/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/TestSecurityConfiguration.java
@@ -5,9 +5,9 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.AuthenticationManager;
-import uk.gov.hmcts.auth.checker.RequestAuthorizer;
 import uk.gov.hmcts.fees.register.api.configuration.AuthCheckerConfiguration;
 import uk.gov.hmcts.fees.register.api.configuration.SpringSecurityConfiguration;
+import uk.gov.hmcts.reform.auth.checker.core.RequestAuthorizer;
 
 @TestConfiguration
 @Import({SpringSecurityConfiguration.class, AuthCheckerConfiguration.class})

--- a/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/base/BaseIntegrationTest.java
+++ b/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/base/BaseIntegrationTest.java
@@ -6,7 +6,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import uk.gov.hmcts.auth.checker.user.UserRequestAuthorizer;
 import uk.gov.hmcts.fees2.register.api.contract.Fee2Dto;
 import uk.gov.hmcts.fees2.register.api.contract.FeeVersionDto;
 import uk.gov.hmcts.fees2.register.api.contract.request.CreateFeeDto;
@@ -19,6 +18,7 @@ import uk.gov.hmcts.fees2.register.data.model.ChannelType;
 import uk.gov.hmcts.fees2.register.data.model.FeeVersionStatus;
 import uk.gov.hmcts.fees2.register.data.service.FeeService;
 import uk.gov.hmcts.fees2.register.util.URIUtils;
+import uk.gov.hmcts.reform.auth.checker.core.user.UserRequestAuthorizer;
 
 import java.math.BigDecimal;
 import java.util.UUID;


### PR DESCRIPTION
Use generic auth-checker-lib rather than idam specific one. https://github.com/hmcts/auth-checker-lib. This one has more features and other services like CMC and CCD using this version.