### PR TITLE
Suppress owasp warning for CVE-2016-7048 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
-    compile(group: 'org.postgresql', name: 'postgresql', version: '42.1.4') {
+    compile(group: 'org.postgresql', name: 'postgresql', version: '42.2.2') {
         exclude(module: 'commons-logging')
         exclude(module: 'slf4j-simple')
     }

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -109,4 +109,8 @@
         <notes>Postgres needs to be upgraded. Ticket PAY-1039 has been created for this task</notes>
         <cve>CVE-2018-1115</cve>
     </suppress>
+    <suppress>
+        <notes>CVE-2016-7048: only for Postgres lt 9.6 and we use 9.6 on Azure.  Also only impacts the installer.</notes>
+        <cve>CVE-2016-7048</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Suppress owasp warning for CVE-2016-7048 as no version resolving the issue is available yet. Also, we don't manage PG installation on Azure.