### PR TITLE
changing to property instead of env variable 

### DIFF
--- a/api/src/main/resources/bootstrap.yaml
+++ b/api/src/main/resources/bootstrap.yaml
@@ -3,4 +3,4 @@ spring:
     propertiesvolume:
       paths: /mnt/secrets/ccpay
       aliases:
-        ccpay.fees-register-api-POSTGRES-PASS: SPRING_DATASOURCE_PASSWORD
+        ccpay.fees-register-api-POSTGRES-PASS: spring.datasource.password


### PR DESCRIPTION
Changing to property instead of env variable as env variables take precedence while using relaxed binding for spring properties.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-1009

### Change description ###

Changing to property instead of env variable as env variables take precedence while using relaxed binding for spring properties.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
