### PR TITLE
PAY-6909: Force DB user to be added to readonly group

### DIFF
--- a/charts/fees-register-api/Chart.yaml
+++ b/charts/fees-register-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "2.0"
 description: Helm chart for the HMCTS fees-register api
 name: fees-register-api
 home: https://github.com/hmcts/ccfr-fees-register-app
-version: 0.4.5
+version: 0.4.6
 maintainers:
   - name: HMCTS Fees & Payments Dev Team
     email: ccpay@hmcts.net

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -102,7 +102,7 @@ module "fees-register-database-v15" {
   pgsql_admin_username = var.postgresql_user
 
   # Setup Access Reader db user
-  force_user_permissions_trigger = "1"
+  force_user_permissions_trigger = "0"
 
   pgsql_databases = [
       {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-6909


### Change description ###
Looks like the fees-register db user is no longer part of the readonly group, reinitiating this through script.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
