### PR TITLE
PAY-7516 enable pact

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -82,7 +82,7 @@ withPipeline(type, product, app) {
     disableLegacyDeployment()
 
     onMaster() {
-        //enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
+        enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
     }
 
     //Sync demo,ithc and perftest with master branch


### PR DESCRIPTION
### Jira link

See [PAY-7516](https://tools.hmcts.net/jira/browse/PAY-7516)

### Change description

Pact can now be re-enabled because the civil team have published a new pact, replacing the failing one.

### Testing done

local pact test

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
