### PR TITLE
CME-529 bump pact libs to fix verification

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -66,7 +66,7 @@ def versions = [
         sonarPitest: '0.5',
         serenity: '4.2.3',
         serenityCucumber: '4.2.3',
-        pact_version    : '4.1.7'
+        pact_version    : '4.6.17'
 ]
 
 sonarqube {
@@ -129,7 +129,6 @@ dependencies {
     contractTestImplementation group: 'au.com.dius.pact.provider', name: 'spring', version: versions.pact_version
     contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5spring', version: versions.pact_version
     contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
-    contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'java8', version: versions.pact_version
     contractTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     contractTestImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
     contractTestImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.2")
@@ -179,7 +178,6 @@ task runProviderPactVerification(type: Test) {
 task providerContractTest(type: Test) {
     logger.lifecycle("Running contract provider Tests")
     useJUnitPlatform()
-    include "uk/gov/hmcts/fees2/register/api/controllers/**"
     testClassesDirs = sourceSets.contractTest.output.classesDirs
     classpath = sourceSets.contractTest.runtimeClasspath
     systemProperty 'pact.rootDir', "pacts"

--- a/api/src/contractTest/java/uk/gov/hmcts/fees2/register/api/controllers/provider/FeeLookupProviderTest.java
+++ b/api/src/contractTest/java/uk/gov/hmcts/fees2/register/api/controllers/provider/FeeLookupProviderTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.fees2.register.data.dto.response.FeeLookupResponseDto;
 import uk.gov.hmcts.fees2.register.data.model.FeeVersionStatus;
 import uk.gov.hmcts.fees2.register.data.service.FeeSearchService;
 import uk.gov.hmcts.fees2.register.data.service.FeeService;
+
 import java.math.BigDecimal;
 
 import static org.mockito.Mockito.when;

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.51.0'
     id 'jacoco'
     id 'maven-publish'
-    id "au.com.dius.pact" version "4.6.14"
+    id "au.com.dius.pact" version "4.6.17"
 }
 
 def versions = [


### PR DESCRIPTION
### Jira link
CME-529

### Change description
Bump pact libs to fix pact verifier not finding published pacts.
