### PR TITLE
PAY-8054: Update to fix approved fees going to Liberata

### DIFF
--- a/api/src/main/java/uk/gov/hmcts/fees2/register/api/controllers/FeeController.java
+++ b/api/src/main/java/uk/gov/hmcts/fees2/register/api/controllers/FeeController.java
@@ -316,6 +316,7 @@ public class FeeController {
                                 @RequestParam(required = false) String siRefId,
                                 @RequestParam(required = false) BigDecimal feeVersionAmount,
                                 @RequestParam(required = false) Boolean discontinued) {
+
         List<Fee2Dto> result;
         SearchFeeDto searchFeeDto = new SearchFeeDto(amount, service, jurisdiction1, jurisdiction2, channel, event, applicantType, unspecifiedClaimAmounts, isDraft);
         SearchFeeVersionDto searchFeeVersionDto = new SearchFeeVersionDto(author, approvedBy, isActive, isExpired, discontinued, feeVersionStatus, description, siRefId, feeVersionAmount);
@@ -458,14 +459,26 @@ public class FeeController {
     @ResponseStatus(HttpStatus.OK)
     public List<Fee2Dto> approvedFees() {
         List<Fee2Dto> result =  search(null, null, null, null, null,
-            null, null, null,null, null,
-            null, null, null, null, null, null, null, null);
+            null, null, null, FeeVersionStatus.approved, null,
+            null, false, true, null, null, null, null, null);
         result = result
             .stream()
             .filter(c -> c.getCurrentVersion()!=null)
             .filter(c -> c.getCurrentVersion().getStatus().equals(FeeVersionStatusDto.approved))
             .collect(Collectors.toList());
 
+        // return only approved versions of the approved fees
+        for (Fee2Dto fee2Dto : result) {
+            if (fee2Dto.getFeeVersionDtos() != null) {
+                List<FeeVersionDto> approvedVersions = fee2Dto.getFeeVersionDtos()
+                    .stream()
+                    .filter(fv -> FeeVersionStatusDto.approved.equals(fv.getStatus()))
+                    .collect(Collectors.toList());
+                fee2Dto.setFeeVersionDtos(approvedVersions);
+            }
+        }
+
+        // remove sensitive info
         for (Fee2Dto fee2Dto : result) {
             for (FeeVersionDto feeVersionDto : fee2Dto.getFeeVersionDtos()) {
                 feeVersionDto.setApprovedBy(null);
@@ -492,7 +505,6 @@ public class FeeController {
             }
 
         }
-
 
         return result;
     }

--- a/api/src/main/java/uk/gov/hmcts/fees2/register/api/controllers/FeeController.java
+++ b/api/src/main/java/uk/gov/hmcts/fees2/register/api/controllers/FeeController.java
@@ -316,7 +316,6 @@ public class FeeController {
                                 @RequestParam(required = false) String siRefId,
                                 @RequestParam(required = false) BigDecimal feeVersionAmount,
                                 @RequestParam(required = false) Boolean discontinued) {
-
         List<Fee2Dto> result;
         SearchFeeDto searchFeeDto = new SearchFeeDto(amount, service, jurisdiction1, jurisdiction2, channel, event, applicantType, unspecifiedClaimAmounts, isDraft);
         SearchFeeVersionDto searchFeeVersionDto = new SearchFeeVersionDto(author, approvedBy, isActive, isExpired, discontinued, feeVersionStatus, description, siRefId, feeVersionAmount);

--- a/api/src/main/java/uk/gov/hmcts/fees2/register/api/controllers/mapper/FeeDtoMapper.java
+++ b/api/src/main/java/uk/gov/hmcts/fees2/register/api/controllers/mapper/FeeDtoMapper.java
@@ -159,7 +159,8 @@ public class FeeDtoMapper {
         List<FeeVersionDto> feeVersionDtos = fee.getFeeVersions().stream().map(this::toFeeVersionDto).collect(Collectors.toList());
         fee2Dto.setFeeVersionDtos(feeVersionDtos);
 
-        FeeVersion currentVersion = fee.getCurrentVersion(false);
+        // current version should always be approved
+        FeeVersion currentVersion = fee.getCurrentVersion(true);
 
         if(currentVersion != null) {
             fee2Dto.setCurrentVersion(toFeeVersionDto(currentVersion));

--- a/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/FeeControllerTest.java
+++ b/api/src/test/java/uk/gov/hmcts/fees2/register/api/controllers/FeeControllerTest.java
@@ -25,7 +25,11 @@ import uk.gov.hmcts.fees2.register.data.model.FeeVersionStatus;
 import uk.gov.hmcts.fees2.register.util.URIUtils;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-8054

### Change description
Defaults the current version to always use the latest approved fee and tidies up the approved fees - this only now gives back the approved versions and not the draft versions.

### Testing done
Local testing, Unit testing, will require testing in the lower environments.

Developer testing completed.
1. approvedFees API - this now correctly brings back FEE0441 approved fees, if there is a draft version or not.
2. approvedFees API - this only contains fee versions which have been approved - no need to send Liberata draft fees.
3. Validated fees with draft versions can now be accessed from PayBubble.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
