### PR TITLE
PAY-8010: Update swagger library to fix access

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ subprojects {
         implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-        implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
+        implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.17'
 
         compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
         compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.8.6'


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-8010


### Change description
Reviewing an ITHC issue, I wasn't able to access the swagger page for the fee register api. This appears to be down to an old library org.springdoc:springdoc-openapi-starter-webmvc-ui causing HTTP 500 errors.

### Testing done
Accessed swagger in PR.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
